### PR TITLE
Mobile browsers always give Unauthorized

### DIFF
--- a/twocheckout/payment_execution.tpl
+++ b/twocheckout/payment_execution.tpl
@@ -57,7 +57,7 @@
             <input class="numeric" id="cvv" type="text" size="4" autocomplete="off"  style="border: #CCCCCC solid 1px; padding: 3px;" required />
         </div>
         <br />
-        <input type="submit" class="button" onclick="retrieveToken()" value="{l s='Submit Payment' mod='twocheckout'}" />
+        <input type="submit" class="button" value="{l s='Submit Payment' mod='twocheckout'}" />
         <div class="block-right">
             <img src="{$module_dir}assets/credit-cards.png" />
         </div>


### PR DESCRIPTION
Remov the onlick function of the submit button so an API call is actually made, otherwise always gives error 300 (Unauthorized)